### PR TITLE
using QT5 instead of PYQT5

### DIFF
--- a/guidata/configtools.py
+++ b/guidata/configtools.py
@@ -289,10 +289,10 @@ def font_is_installed(font: str) -> list[str]:
         list[str]: list of installed fonts
     """
     # Importing Qt here because this module should be independent from it
-    from qtpy import PYQT5
+    from qtpy import QT5
     from qtpy import QtGui as QG  # pylint: disable=import-outside-toplevel
 
-    if PYQT5:
+    if QT5:
         fontfamilies = QG.QFontDatabase().families()
     else:
         # Qt6


### PR DESCRIPTION
The condition for the follow code should be QT5 instead of PYQT5:
```python
    if PYQT5:
        fontfamilies = QG.QFontDatabase().families()
    else:
        # Qt6
        fontfamilies = QG.QFontDatabase.families()
    return [fam for fam in fontfamilies if str(fam) == font]
```